### PR TITLE
Fix no previous tags being seen after checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
           node-version: '16'


### PR DESCRIPTION
The checkout action, by default, does a shallow clone and only has the ref that triggered the build. Now it will clone the entire git history. This might be slightly slower but at least it'll see the previous tags. When it wasn't seeing the other tags, it always thought that it was the very first version.

See here https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches