### PR TITLE
Enable CORS

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/config/SecurityConfig.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           .authenticationEntryPoint(problemSupport)
           .accessDeniedHandler(problemSupport);
     // @formatter:on
+    // https://www.baeldung.com/spring-cors#cors-with-spring-security
+    http.cors();
   }
 
   @Bean

--- a/city/src/main/java/io/github/incplusplus/beacon/city/config/SecurityConfig.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/config/SecurityConfig.java
@@ -63,6 +63,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
           .authenticationEntryPoint(problemSupport)
           .accessDeniedHandler(problemSupport);
     // @formatter:on
+    // https://www.baeldung.com/spring-cors#cors-with-spring-security
+    http.cors();
   }
 
   @Bean

--- a/common/src/main/java/io/github/incplusplus/beacon/common/config/MvcConfigurationBase.java
+++ b/common/src/main/java/io/github/incplusplus/beacon/common/config/MvcConfigurationBase.java
@@ -3,6 +3,7 @@ package io.github.incplusplus.beacon.common.config;
 import java.io.IOException;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.PathResourceResolver;
@@ -13,6 +14,20 @@ import org.springframework.web.servlet.resource.PathResourceResolver;
  * it. Be sure to annotate your subclass with the {@link Configuration} annotation.
  */
 public class MvcConfigurationBase implements WebMvcConfigurer {
+
+  /**
+   * https://www.baeldung.com/spring-cors#1-javaconfig
+   *
+   * @param registry the registry
+   */
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry
+        .addMapping("/**")
+        .allowedMethods("*")
+        .allowedOriginPatterns("*")
+        .allowCredentials(true);
+  }
 
   /**
    * The way the Swagger UI is rendered is by reading the OpenAPI specification YAML file. The way


### PR DESCRIPTION
Our frontend will be hosted on a different origin than the backend. Because the JS fetch API will enable pre-flight checks, all API calls will fail. This enables CORS support on Spring's end. Now, the browser should receive the appropriate CORS header in the server's response to the browser's pre-flight check.

See the following resources for more info:
- https://mobilejazz.com/blog/which-security-risks-do-cors-imply/
- https://www.baeldung.com/spring-cors
- https://spring.io/blog/2015/06/08/cors-support-in-spring-framework