### PR TITLE
Add the ID of the City in the "get Tower by ID" City endpoint's response

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
@@ -16,6 +16,11 @@ public class CityManagementController implements CityManagementApi {
   }
 
   @Override
+  public ResponseEntity<CityDto> getCity(String cityId) {
+    return ResponseEntity.of(cityService.getCity(cityId));
+  }
+
+  @Override
   public ResponseEntity<List<CityDto>> listRegisteredCities() {
     return ResponseEntity.ok(cityService.getCities());
   }

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
@@ -72,4 +72,8 @@ public class CityService {
         .map(cityMapper::cityToCityDto)
         .collect(Collectors.toList());
   }
+
+  public Optional<CityDto> getCity(String cityId) {
+    return cityRepository.findById(cityId).map(cityMapper::cityToCityDto);
+  }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
@@ -24,8 +24,7 @@ public class TowerController implements TowersApi {
 
   @Override
   public ResponseEntity<TowerDto> getTowerById(String towerId) {
-    // TODO: Implement
-    return null;
+    return ResponseEntity.of(towerService.getTower(towerId));
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
@@ -11,5 +11,15 @@ public interface TowerMapper {
   @Mapping(target = "channels", ignore = true)
   Tower towerDtoToTower(TowerDto towerDto);
 
+  /*
+  TODO: The city ID is something that isn't persisted. Instead, It's retrieved from the IDENTITY file.
+   Because of this, we will set the cityId field manually just before returning the DTO.
+   Look into whether MapStruct will let us do this by having a second parameter to this method
+   that allows for the manual specification of a field. If not, also see if we can provide an
+   implementation for this method that uses as much of the automated part as possible and manually
+   assigns the cityId with the second parameter. Until this is done, some of the endpoints will
+   return Towers without a cityId which will probably cause issues with the frontend.
+   */
+  @Mapping(target = "cityId", ignore = true)
   TowerDto towerToTowerDto(Tower tower);
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -5,7 +5,9 @@ import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
 import io.github.incplusplus.beacon.city.mapper.TowerMapper;
 import io.github.incplusplus.beacon.city.persistence.dao.TowerRepository;
 import io.github.incplusplus.beacon.city.persistence.model.Tower;
+import io.github.incplusplus.beacon.city.spring.AutoRegisterCity;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,11 +16,15 @@ import org.springframework.stereotype.Service;
 public class TowerService {
   private final TowerMapper towerMapper;
   private final TowerRepository towerRepository;
+  private final AutoRegisterCity autoRegisterCity;
 
   public TowerService(
-      @Autowired TowerMapper towerMapper, @Autowired TowerRepository towerRepository) {
+      @Autowired TowerMapper towerMapper,
+      @Autowired TowerRepository towerRepository,
+      AutoRegisterCity autoRegisterCity) {
     this.towerMapper = towerMapper;
     this.towerRepository = towerRepository;
+    this.autoRegisterCity = autoRegisterCity;
   }
 
   public TowerDto createTower(TowerDto towerDto) {
@@ -30,5 +36,12 @@ public class TowerService {
     return Streams.stream(towerRepository.findAll())
         .map(towerMapper::towerToTowerDto)
         .collect(Collectors.toList());
+  }
+
+  public Optional<TowerDto> getTower(String towerId) {
+    Optional<TowerDto> towerDto =
+        towerRepository.findById(towerId).map(towerMapper::towerToTowerDto);
+    towerDto.ifPresent(dto -> dto.setCityId(autoRegisterCity.getCityId()));
+    return towerDto;
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/spring/AutoRegisterCity.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/spring/AutoRegisterCity.java
@@ -43,6 +43,9 @@ public class AutoRegisterCity implements ApplicationListener<ContextRefreshedEve
       return;
     }
 
+    // TODO: Even if the IDENTITY file exists, we should still check with the CIS if these
+    // credentials
+    //  are still valid.
     log.info("Checking if this City has been assigned an identity...");
     // Check if saved ID and password exist locally
     if (identityFile.exists()) {

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -133,6 +133,24 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
+  '/cities/{city-id}':
+    parameters:
+      - $ref: '#/components/parameters/city-id'
+    get:
+      tags: [ City Management ]
+      summary: Get a City by ID
+      operationId: getCity
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/City'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/join/{tower-invite-code}':
     parameters:
       - name: tower-invite-code

--- a/common/src/main/openapi/parameters/_index.yaml
+++ b/common/src/main/openapi/parameters/_index.yaml
@@ -6,3 +6,5 @@ channel-id:
   $ref: "./path/channel-id.yml"
 message-id:
   $ref: "./path/message-id.yml"
+city-id:
+  $ref: "./path/city-id.yml"

--- a/common/src/main/openapi/parameters/path/city-id.yml
+++ b/common/src/main/openapi/parameters/path/city-id.yml
@@ -1,0 +1,6 @@
+name: city-id
+in: path
+description: The ID of a City
+required: true
+schema:
+  type: string

--- a/common/src/main/openapi/schemas/Tower.yml
+++ b/common/src/main/openapi/schemas/Tower.yml
@@ -5,6 +5,10 @@ properties:
     description: The unique ID of this Tower
     type: string
     example: 507f1f77bcf86cd799439011
+  city_id:
+    description: The ID of the City that this Tower belongs to
+    type: string
+    example: 507f1f77bcf86cd799439011
   name:
     description: The name of this tower
     type: string


### PR DESCRIPTION
Right now I'm working on adding state management and API interaction to the frontend. One of the snafus I ran into is as follows:

Given a Tower, how does the frontend know what City URL to point at to send HTTP requests to? It doesn't. It would need to ask the CIS for that information. I figured that it would make sense for the City...


Wait. I might be dumb. This is only an issue when I'm doing hardcoded stuff. Once the client is actually able to retrieve tower memberships, this will no longer be necessary. Oops.