### PR TITLE
Add Tower membership features

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityInterserviceCommunicationsController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityInterserviceCommunicationsController.java
@@ -5,8 +5,10 @@ import io.github.incplusplus.beacon.centralidentityserver.generated.dto.CreateTo
 import io.github.incplusplus.beacon.centralidentityserver.generated.dto.NewCityDto;
 import io.github.incplusplus.beacon.centralidentityserver.generated.dto.UserAccountDto;
 import io.github.incplusplus.beacon.centralidentityserver.mapper.UserMapper;
+import io.github.incplusplus.beacon.centralidentityserver.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.centralidentityserver.service.CityService;
 import io.github.incplusplus.beacon.centralidentityserver.service.UserService;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CityInterserviceCommunicationsController implements CityInterserviceCommunicationsApi {
 
   private final UserDetailsService userDetailsService;
+  private final IAuthenticationFacade authenticationFacade;
   private final PasswordEncoder passwordEncoder;
   private final CityService cityService;
   private final UserService userService;
@@ -28,15 +31,23 @@ public class CityInterserviceCommunicationsController implements CityInterservic
   @Autowired
   public CityInterserviceCommunicationsController(
       UserDetailsService userDetailsService,
+      IAuthenticationFacade authenticationFacade,
       PasswordEncoder passwordEncoder,
       CityService cityService,
       UserService userService,
       UserMapper userMapper) {
     this.userDetailsService = userDetailsService;
+    this.authenticationFacade = authenticationFacade;
     this.passwordEncoder = passwordEncoder;
     this.cityService = cityService;
     this.userService = userService;
     this.userMapper = userMapper;
+  }
+
+  @Override
+  public ResponseEntity<List<String>> addCityMembers(List<String> newMembers) {
+    return ResponseEntity.ok(
+        cityService.addCityMembers(authenticationFacade.getAuthentication().getName(), newMembers));
   }
 
   @Override
@@ -47,9 +58,28 @@ public class CityInterserviceCommunicationsController implements CityInterservic
   }
 
   @Override
+  public ResponseEntity<List<String>> getCityMembers() {
+    return ResponseEntity.ok(
+        cityService.getCityMembers(authenticationFacade.getAuthentication().getName()));
+  }
+
+  @Override
   public ResponseEntity<NewCityDto> registerCity(String cityHostName) {
     NewCityDto registered = cityService.registerNewCity(cityHostName);
     return ResponseEntity.ok(registered);
+  }
+
+  @Override
+  public ResponseEntity<List<String>> removeCityMembers(List<String> userIds) {
+    return ResponseEntity.ok(
+        cityService.removeCityMembers(authenticationFacade.getAuthentication().getName(), userIds));
+  }
+
+  @Override
+  public ResponseEntity<List<String>> setCityMembers(List<String> cityMembers) {
+    return ResponseEntity.ok(
+        cityService.setCityMembers(
+            authenticationFacade.getAuthentication().getName(), cityMembers));
   }
 
   @Override
@@ -57,6 +87,8 @@ public class CityInterserviceCommunicationsController implements CityInterservic
     UserDetails userDetails;
     UserAccountDto userAccountDto;
     try {
+      // TODO: Why the hell did I do all this logic in the controller? Move this to a service at
+      //  some point.
       // TODO In the future, check these for null. Otherwise, a 500 happens.
       userDetails = userDetailsService.loadUserByUsername(username);
     } catch (UsernameNotFoundException e) {

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
@@ -16,6 +16,11 @@ public class CityManagementController implements CityManagementApi {
   }
 
   @Override
+  public ResponseEntity<CityDto> getCity(String cityId) {
+    return ResponseEntity.of(cityService.getCity(cityId));
+  }
+
+  @Override
   public ResponseEntity<List<CityDto>> listRegisteredCities() {
     return ResponseEntity.ok(cityService.getCities());
   }

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityManagementController.java
@@ -2,6 +2,7 @@ package io.github.incplusplus.beacon.centralidentityserver.controller;
 
 import io.github.incplusplus.beacon.centralidentityserver.generated.controller.CityManagementApi;
 import io.github.incplusplus.beacon.centralidentityserver.generated.dto.CityDto;
+import io.github.incplusplus.beacon.centralidentityserver.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.centralidentityserver.service.CityService;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -10,14 +11,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CityManagementController implements CityManagementApi {
   private final CityService cityService;
+  private final IAuthenticationFacade authenticationFacade;
 
-  public CityManagementController(CityService cityService) {
+  public CityManagementController(
+      CityService cityService, IAuthenticationFacade authenticationFacade) {
     this.cityService = cityService;
+    this.authenticationFacade = authenticationFacade;
   }
 
   @Override
   public ResponseEntity<CityDto> getCity(String cityId) {
     return ResponseEntity.of(cityService.getCity(cityId));
+  }
+
+  @Override
+  public ResponseEntity<List<CityDto>> listCitiesMemberOf() {
+    return ResponseEntity.ok(
+        cityService.listCitiesMemberOf(authenticationFacade.getAuthentication().getName()));
   }
 
   @Override

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/persistence/dao/CityRepository.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/persistence/dao/CityRepository.java
@@ -1,10 +1,12 @@
 package io.github.incplusplus.beacon.centralidentityserver.persistence.dao;
 
 import io.github.incplusplus.beacon.centralidentityserver.persistence.model.City;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CityRepository extends CrudRepository<City, String> {
-
   Optional<City> findByBasePath(String cityBasePath);
+
+  List<City> findAllByMemberUsersContains(String userId);
 }

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/persistence/model/City.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/persistence/model/City.java
@@ -1,5 +1,6 @@
 package io.github.incplusplus.beacon.centralidentityserver.persistence.model;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,4 +17,18 @@ public class City {
   @Id private String id;
   private String password;
   private String basePath;
+  /**
+   * This list contains the IDs of any users who are a member of one or more Towers that this City
+   * contains. It is the responsibility of the City to add and remove users from this collection
+   * when applicable. For example, if a user (who isn't a member of any Towers in this City) joins
+   * one of the Towers this City contains. It is the City's responsibility to notify the CIS that
+   * there is a new user who is a "member of the City".
+   *
+   * <p>The City obviously doesn't have members. The only membership mechanic in this application is
+   * users being members of Towers. The "members of the City" is a concept that was created for the
+   * express purpose of allowing the frontend to ask the <i>specifically the <b>CIS</b></i> "what
+   * Towers am I a member of and what Cities do I need to ask to retrieve their information?" and is
+   * not to be taken as a City having some kind of membership mechanic.
+   */
+  private List<String> memberUsers;
 }

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
@@ -7,6 +7,7 @@ import io.github.incplusplus.beacon.centralidentityserver.mapper.CityMapper;
 import io.github.incplusplus.beacon.centralidentityserver.persistence.dao.CityRepository;
 import io.github.incplusplus.beacon.centralidentityserver.persistence.model.City;
 import io.github.incplusplus.beacon.centralidentityserver.persistence.model.User;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -65,6 +66,9 @@ public class CityService {
     // A UUID should work decently well for a password I suppose.
     String passwordRaw = UUID.randomUUID().toString();
     city.setPassword(passwordEncoder.encode(passwordRaw));
+    // The City needs to have the members list initialized. Otherwise, it'll be null and cause
+    // problems for us when we want to retrieve the list and modify it.
+    city.setMemberUsers(new ArrayList<>());
     NewCityDto newCity = cityMapper.cityToNewCityDto(cityRepository.save(city));
     // We don't want to send back the encoded password.
     // Otherwise, the City won't ever be able to authenticate properly

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
@@ -72,4 +72,8 @@ public class CityService {
         .map(cityMapper::cityToCityDto)
         .collect(Collectors.toList());
   }
+
+  public Optional<CityDto> getCity(String cityId) {
+    return cityRepository.findById(cityId).map(cityMapper::cityToCityDto);
+  }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
@@ -24,8 +24,7 @@ public class TowerController implements TowersApi {
 
   @Override
   public ResponseEntity<TowerDto> getTowerById(String towerId) {
-    // TODO: Implement
-    return null;
+    return ResponseEntity.of(towerService.getTower(towerId));
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
@@ -2,6 +2,7 @@ package io.github.incplusplus.beacon.city.controller;
 
 import io.github.incplusplus.beacon.city.generated.controller.TowersApi;
 import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
+import io.github.incplusplus.beacon.city.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.city.service.TowerService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,9 +13,19 @@ import org.springframework.stereotype.Controller;
 public class TowerController implements TowersApi {
 
   private final TowerService towerService;
+  private final IAuthenticationFacade authenticationFacade;
 
-  public TowerController(@Autowired TowerService towerService) {
+  @Autowired
+  public TowerController(TowerService towerService, IAuthenticationFacade authenticationFacade) {
     this.towerService = towerService;
+    this.authenticationFacade = authenticationFacade;
+  }
+
+  @Override
+  public ResponseEntity<Boolean> checkIfMemberOfTower(String towerId) {
+    return ResponseEntity.ok(
+        towerService.isUserMemberOfTower(
+            authenticationFacade.getAuthentication().getName(), towerId));
   }
 
   @Override
@@ -25,6 +36,24 @@ public class TowerController implements TowersApi {
   @Override
   public ResponseEntity<TowerDto> getTowerById(String towerId) {
     return ResponseEntity.of(towerService.getTower(towerId));
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteTower(String towerId) {
+    towerService.deleteTower(towerId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  public ResponseEntity<TowerDto> joinTower(String towerId) {
+    return ResponseEntity.ok(
+        towerService.joinTower(authenticationFacade.getAuthentication().getName(), towerId));
+  }
+
+  @Override
+  public ResponseEntity<TowerDto> leaveTower(String towerId) {
+    return ResponseEntity.ok(
+        towerService.leaveTower(authenticationFacade.getAuthentication().getName(), towerId));
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
@@ -30,7 +30,8 @@ public class TowerController implements TowersApi {
 
   @Override
   public ResponseEntity<TowerDto> createTower(TowerDto towerDto) {
-    return ResponseEntity.ok(towerService.createTower(towerDto));
+    return ResponseEntity.ok(
+        towerService.createTower(authenticationFacade.getAuthentication().getName(), towerDto));
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
@@ -2,6 +2,7 @@ package io.github.incplusplus.beacon.city.controller;
 
 import io.github.incplusplus.beacon.city.generated.controller.UsersApi;
 import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
+import io.github.incplusplus.beacon.city.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.city.service.TowerService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,10 +12,12 @@ import org.springframework.stereotype.Controller;
 @Controller
 public class UserController implements UsersApi {
   private final TowerService towerService;
+  private final IAuthenticationFacade authenticationFacade;
 
   @Autowired
-  public UserController(TowerService towerService) {
+  public UserController(TowerService towerService, IAuthenticationFacade authenticationFacade) {
     this.towerService = towerService;
+    this.authenticationFacade = authenticationFacade;
   }
 
   @Override
@@ -25,6 +28,14 @@ public class UserController implements UsersApi {
 
   @Override
   public ResponseEntity<List<TowerDto>> getUserTowerMemberships(String userAccountId) {
-    return ResponseEntity.ok(towerService.getTowersUserIsMemberOf(userAccountId));
+    // If no account ID was specified
+    if (userAccountId == null || userAccountId.isBlank()) {
+      // Provide the username of the user who sent this request and get the Towers they're in
+      return ResponseEntity.ok(
+          towerService.getTowersUserIsMemberOf(
+              authenticationFacade.getAuthentication().getName(), true));
+    }
+    // Otherwise, get the Towers that the user specified by the provided ID is a member of
+    return ResponseEntity.ok(towerService.getTowersUserIsMemberOf(userAccountId, false));
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
@@ -2,12 +2,20 @@ package io.github.incplusplus.beacon.city.controller;
 
 import io.github.incplusplus.beacon.city.generated.controller.UsersApi;
 import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
+import io.github.incplusplus.beacon.city.service.TowerService;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class UserController implements UsersApi {
+  private final TowerService towerService;
+
+  @Autowired
+  public UserController(TowerService towerService) {
+    this.towerService = towerService;
+  }
 
   @Override
   public ResponseEntity<String> createInvite(String towerId) {
@@ -17,7 +25,6 @@ public class UserController implements UsersApi {
 
   @Override
   public ResponseEntity<List<TowerDto>> getUserTowerMemberships(String userAccountId) {
-    // TODO Implement
-    return null;
+    return ResponseEntity.ok(towerService.getTowersUserIsMemberOf(userAccountId));
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
@@ -11,5 +11,15 @@ public interface TowerMapper {
   @Mapping(target = "channels", ignore = true)
   Tower towerDtoToTower(TowerDto towerDto);
 
+  /*
+  TODO: The city ID is something that isn't persisted. Instead, It's retrieved from the IDENTITY file.
+   Because of this, we will set the cityId field manually just before returning the DTO.
+   Look into whether MapStruct will let us do this by having a second parameter to this method
+   that allows for the manual specification of a field. If not, also see if we can provide an
+   implementation for this method that uses as much of the automated part as possible and manually
+   assigns the cityId with the second parameter. Until this is done, some of the endpoints will
+   return Towers without a cityId which will probably cause issues with the frontend.
+   */
+  @Mapping(target = "cityId", ignore = true)
   TowerDto towerToTowerDto(Tower tower);
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/mapper/TowerMapper.java
@@ -11,15 +11,19 @@ public interface TowerMapper {
   @Mapping(target = "channels", ignore = true)
   Tower towerDtoToTower(TowerDto towerDto);
 
-  /*
-  TODO: The city ID is something that isn't persisted. Instead, It's retrieved from the IDENTITY file.
-   Because of this, we will set the cityId field manually just before returning the DTO.
-   Look into whether MapStruct will let us do this by having a second parameter to this method
-   that allows for the manual specification of a field. If not, also see if we can provide an
-   implementation for this method that uses as much of the automated part as possible and manually
-   assigns the cityId with the second parameter. Until this is done, some of the endpoints will
-   return Towers without a cityId which will probably cause issues with the frontend.
+  /**
+   * Map a Tower internal document to a Tower DTO.
+   *
+   * <p>The city ID is something that isn't persisted. Instead, It's retrieved from the IDENTITY
+   * file. Because of this, we will set the cityId field manually just before returning the DTO.
+   *
+   * @param tower a Tower that is being transformed to a DTO
+   * @param cityId the ID of the City this Tower belongs to (should always be THIS City's ID)
+   * @return a TowerDto representing the Tower document
+   * @see <a
+   *     href="https://mapstruct.org/documentation/stable/reference/html/#mappings-with-several-source-parameters">MapStruct
+   *     documentation on multiple parameters</a>
    */
-  @Mapping(target = "cityId", ignore = true)
-  TowerDto towerToTowerDto(Tower tower);
+  @Mapping(source = "cityId", target = "cityId")
+  TowerDto towerToTowerDto(Tower tower, String cityId);
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/persistence/dao/TowerRepository.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/persistence/dao/TowerRepository.java
@@ -6,4 +6,10 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface TowerRepository extends CrudRepository<Tower, String> {
   List<Tower> findAllByMemberAccountIdsContains(String accountId);
+
+  boolean existsTowerByMemberAccountIdsContains(String accountId);
+
+  int countTowersByMemberAccountIdsContains(String accountId);
+
+  List<Tower> findTowersByIdIsNot(String towerId);
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/persistence/dao/TowerRepository.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/persistence/dao/TowerRepository.java
@@ -1,6 +1,9 @@
 package io.github.incplusplus.beacon.city.persistence.dao;
 
 import io.github.incplusplus.beacon.city.persistence.model.Tower;
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
-public interface TowerRepository extends CrudRepository<Tower, String> {}
+public interface TowerRepository extends CrudRepository<Tower, String> {
+  List<Tower> findAllByMemberAccountIdsContains(String accountId);
+}

--- a/city/src/main/java/io/github/incplusplus/beacon/city/persistence/model/Tower.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/persistence/model/Tower.java
@@ -20,6 +20,7 @@ public class Tower {
   private String name;
   private String adminAccountId;
   private List<String> moderatorAccountIds = null;
+  private List<String> memberAccountIds;
 
   @ReadOnlyProperty
   @DocumentReference(lookup = "{'towerId':?#{#self._id} }")

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/ChannelService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/ChannelService.java
@@ -59,6 +59,7 @@ public class ChannelService {
       throw new RuntimeException("Channel not found");
     }
     Optional<Channel> deleted = channelRepository.deleteByIdAndTowerId(channelId, towerId);
+    // TODO: Delete all messages that were in chis channel.
     if (deleted.isEmpty()) {
       return Optional.empty();
     }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -66,7 +66,19 @@ public class TowerService {
     return towerDto;
   }
 
-  public List<TowerDto> getTowersUserIsMemberOf(String userAccountId) {
+  /**
+   * Get the list of Towers the specified user is a member of
+   *
+   * @param usernameOrAccountId the username or account ID of the target user
+   * @param isUsername true if {@code usernameOrAccountId} is being provided a username, false if it
+   *     is a user ID
+   * @return a list of Towers that the specified user is a member of
+   */
+  public List<TowerDto> getTowersUserIsMemberOf(String usernameOrAccountId, boolean isUsername) {
+    String userAccountId =
+        isUsername
+            ? loginAuthenticationProvider.getIdForUsername(usernameOrAccountId)
+            : usernameOrAccountId;
     return towerRepository.findAllByMemberAccountIdsContains(userAccountId).stream()
         .map(tower -> towerMapper.towerToTowerDto(tower, autoRegisterCity.getCityId()))
         .collect(Collectors.toList());

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -7,18 +7,25 @@ import io.github.incplusplus.beacon.city.persistence.dao.TowerRepository;
 import io.github.incplusplus.beacon.city.persistence.model.Tower;
 import io.github.incplusplus.beacon.city.security.LoginAuthenticationProvider;
 import io.github.incplusplus.beacon.city.spring.AutoRegisterCity;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class TowerService {
+  private static final String CIS_MEMBERSHIPS_ENDPOINT_URI = "/city-cis-intercom/memberships";
   private final TowerMapper towerMapper;
   private final TowerRepository towerRepository;
   private final AutoRegisterCity autoRegisterCity;
   private final LoginAuthenticationProvider loginAuthenticationProvider;
+  private WebClient cisWebClient;
 
   @Autowired
   public TowerService(
@@ -32,10 +39,16 @@ public class TowerService {
     this.loginAuthenticationProvider = loginAuthenticationProvider;
   }
 
-  public TowerDto createTower(TowerDto towerDto) {
-    // TODO: Add the admin ID to the list of members when the tower is created
+  public TowerDto createTower(String username, TowerDto towerDto) {
+    String userId = loginAuthenticationProvider.getIdForUsername(username);
+    // Initialize member IDs
+    towerDto.setMemberAccountIds(new ArrayList<>());
+    // Initialize moderator ID list
+    towerDto.setModeratorAccountIds(new ArrayList<>());
+    // Save this new Tower to the database
     Tower tower = towerRepository.save(towerMapper.towerDtoToTower(towerDto));
-    return towerMapper.towerToTowerDto(tower);
+    // Make the creator of the tower join the tower and return the changed tower
+    return joinTower(username, tower.getId());
   }
 
   public List<TowerDto> getTowers() {
@@ -79,8 +92,29 @@ public class TowerService {
       // TODO: Make a proper exception
       throw new RuntimeException("User is already a member of that tower");
     }
-
-    // TODO: Also contact the CIS to add the "member of this City" if applicable
+    // region Contact the CIS to add a new "member of this City" if applicable
+    boolean userPartOfCityBeforeJoiningThisTower =
+        towerRepository.existsTowerByMemberAccountIdsContains(userId);
+    // If this is the first Tower hosted by this City that the user has joined...
+    if (!userPartOfCityBeforeJoiningThisTower) {
+      // Let the CIS know that the user is now "a member of this City"
+      try {
+        List<String> membersOfCity =
+            getCisWebClient()
+                .put()
+                //            .contentType(MediaType.APPLICATION_JSON)
+                .uri(CIS_MEMBERSHIPS_ENDPOINT_URI)
+                .bodyValue(List.of(userId))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<String>>() {})
+                .block(Duration.ofSeconds(30));
+      } catch (Exception e) {
+        // TODO: Make a proper exception that reflects that the City-to-CIS communication failed. It
+        //  should cause a 500 error as this is an internal issue.
+        throw new RuntimeException(e);
+      }
+    }
+    // endregion
     tower.getMemberAccountIds().add(userId);
     return towerMapper.towerToTowerDto(towerRepository.save(tower));
   }
@@ -98,18 +132,92 @@ public class TowerService {
       throw new RuntimeException(
           "User is no longer in that tower. Can't leave a tower you weren't even in.");
     }
-    // TODO: Also contact the CIS to remove the "member of this City" if applicable
+    // region Contact the CIS to remove the "member of this City" if applicable
+    boolean userWillNoLongerBeMemberOfAnyTowersWithinThisCity =
+        towerRepository.countTowersByMemberAccountIdsContains(userId) < 2;
+    // If the user will no longer be a member of any Towers within this City
+    // after they're removed from this tower...
+    if (userWillNoLongerBeMemberOfAnyTowersWithinThisCity) {
+      // Let the CIS know to remove them from the "members of this City"
+      try {
+        List<String> membersOfCity =
+            getCisWebClient()
+                .method(HttpMethod.DELETE)
+                //            .contentType(MediaType.APPLICATION_JSON)
+                .uri(CIS_MEMBERSHIPS_ENDPOINT_URI)
+                .bodyValue(List.of(userId))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<String>>() {})
+                .block(Duration.ofSeconds(30));
+      } catch (Exception e) {
+        // TODO: Make a proper exception that reflects that the City-to-CIS communication failed. It
+        // should cause a 500 error as this is an internal issue.
+        throw new RuntimeException(e);
+      }
+    }
+    // endregion
     tower.getMemberAccountIds().remove(userId);
     return towerMapper.towerToTowerDto(towerRepository.save(tower));
   }
 
   public void deleteTower(String towerId) {
     if (towerRepository.existsById(towerId)) {
-      // TODO: Also have this contact the CIS to remove "members of this City" if applicable
+      // region Contact the CIS to remove "members of this City" if applicable
+      // Get the list of members in this specific Tower
+      @SuppressWarnings("OptionalGetWithoutIsPresent")
+      List<String> membersOfThisTower =
+          towerRepository.findById(towerId).get().getMemberAccountIds();
+      // Get the list of members of all towers except this one
+      List<String> membersOfOtherTowers =
+          towerRepository.findTowersByIdIsNot(towerId).stream()
+              // Create a stream of all the members of all the selected Towers
+              .flatMap(tower -> tower.getMemberAccountIds().stream())
+              // Remove duplicates
+              .distinct()
+              .toList();
+      // Get the list of members who are unique to this Tower and aren't members of any other
+      // Tower within this City.
+      List<String> membersUniqueToThisTower =
+          membersOfOtherTowers.stream()
+              .filter(member -> !membersOfOtherTowers.contains(member))
+              .toList();
+
+      // Let the CIS know to remove the "members of this City" who are members of this Tower and no
+      // other Towers within this City.
+      List<String> membersOfCity =
+          getCisWebClient()
+              .method(HttpMethod.DELETE)
+              //            .contentType(MediaType.APPLICATION_JSON)
+              .uri(CIS_MEMBERSHIPS_ENDPOINT_URI)
+              .bodyValue(membersUniqueToThisTower)
+              .retrieve()
+              .bodyToMono(new ParameterizedTypeReference<List<String>>() {})
+              .block(Duration.ofSeconds(30));
+      // endregion
       towerRepository.deleteById(towerId);
+      // TODO: Delete the channels in this Tower (and the messages too)
     } else {
       // TODO: Make this a proper exception
       throw new RuntimeException("Tower not found");
     }
+  }
+
+  /**
+   * @return the WebClient for interacting with the CIS. This isn't put into a field in the
+   *     constructor because the City ID and password aren't initialized at start and the
+   *     setBasicAuth method will throw an exception if either of its parameters are null.
+   */
+  private WebClient getCisWebClient() {
+    if (this.cisWebClient == null) {
+      this.cisWebClient =
+          WebClient.builder()
+              .baseUrl(autoRegisterCity.getCISUrl())
+              .defaultHeaders(
+                  header ->
+                      header.setBasicAuth(
+                          autoRegisterCity.getCityId(), autoRegisterCity.getCityCISPassword()))
+              .build();
+    }
+    return this.cisWebClient;
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -53,20 +53,22 @@ public class TowerService {
 
   public List<TowerDto> getTowers() {
     return Streams.stream(towerRepository.findAll())
-        .map(towerMapper::towerToTowerDto)
+        .map(tower -> towerMapper.towerToTowerDto(tower, autoRegisterCity.getCityId()))
         .collect(Collectors.toList());
   }
 
   public Optional<TowerDto> getTower(String towerId) {
     Optional<TowerDto> towerDto =
-        towerRepository.findById(towerId).map(towerMapper::towerToTowerDto);
+        towerRepository
+            .findById(towerId)
+            .map(tower -> towerMapper.towerToTowerDto(tower, autoRegisterCity.getCityId()));
     towerDto.ifPresent(dto -> dto.setCityId(autoRegisterCity.getCityId()));
     return towerDto;
   }
 
   public List<TowerDto> getTowersUserIsMemberOf(String userAccountId) {
     return towerRepository.findAllByMemberAccountIdsContains(userAccountId).stream()
-        .map(towerMapper::towerToTowerDto)
+        .map(tower -> towerMapper.towerToTowerDto(tower, autoRegisterCity.getCityId()))
         .collect(Collectors.toList());
   }
 
@@ -116,7 +118,7 @@ public class TowerService {
     }
     // endregion
     tower.getMemberAccountIds().add(userId);
-    return towerMapper.towerToTowerDto(towerRepository.save(tower));
+    return towerMapper.towerToTowerDto(towerRepository.save(tower), autoRegisterCity.getCityId());
   }
 
   public TowerDto leaveTower(String username, String towerId) {
@@ -157,7 +159,7 @@ public class TowerService {
     }
     // endregion
     tower.getMemberAccountIds().remove(userId);
-    return towerMapper.towerToTowerDto(towerRepository.save(tower));
+    return towerMapper.towerToTowerDto(towerRepository.save(tower), autoRegisterCity.getCityId());
   }
 
   public void deleteTower(String towerId) {

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -5,7 +5,9 @@ import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
 import io.github.incplusplus.beacon.city.mapper.TowerMapper;
 import io.github.incplusplus.beacon.city.persistence.dao.TowerRepository;
 import io.github.incplusplus.beacon.city.persistence.model.Tower;
+import io.github.incplusplus.beacon.city.spring.AutoRegisterCity;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,11 +16,15 @@ import org.springframework.stereotype.Service;
 public class TowerService {
   private final TowerMapper towerMapper;
   private final TowerRepository towerRepository;
+  private final AutoRegisterCity autoRegisterCity;
 
   public TowerService(
-      @Autowired TowerMapper towerMapper, @Autowired TowerRepository towerRepository) {
+      @Autowired TowerMapper towerMapper,
+      @Autowired TowerRepository towerRepository,
+      AutoRegisterCity autoRegisterCity) {
     this.towerMapper = towerMapper;
     this.towerRepository = towerRepository;
+    this.autoRegisterCity = autoRegisterCity;
   }
 
   public TowerDto createTower(TowerDto towerDto) {
@@ -30,5 +36,12 @@ public class TowerService {
     return Streams.stream(towerRepository.findAll())
         .map(towerMapper::towerToTowerDto)
         .collect(Collectors.toList());
+  }
+
+  public Optional<TowerDto> getTower(String towerId) {
+    Optional<TowerDto> towerDto =
+        towerRepository.findById(towerId).map(towerMapper::towerToTowerDto);
+    towerDto.ifPresent(dto -> dto.setCityId(autoRegisterCity.getCityId()));
+    return towerDto;
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -5,6 +5,7 @@ import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
 import io.github.incplusplus.beacon.city.mapper.TowerMapper;
 import io.github.incplusplus.beacon.city.persistence.dao.TowerRepository;
 import io.github.incplusplus.beacon.city.persistence.model.Tower;
+import io.github.incplusplus.beacon.city.security.LoginAuthenticationProvider;
 import io.github.incplusplus.beacon.city.spring.AutoRegisterCity;
 import java.util.List;
 import java.util.Optional;
@@ -17,17 +18,22 @@ public class TowerService {
   private final TowerMapper towerMapper;
   private final TowerRepository towerRepository;
   private final AutoRegisterCity autoRegisterCity;
+  private final LoginAuthenticationProvider loginAuthenticationProvider;
 
+  @Autowired
   public TowerService(
-      @Autowired TowerMapper towerMapper,
-      @Autowired TowerRepository towerRepository,
-      AutoRegisterCity autoRegisterCity) {
+      TowerMapper towerMapper,
+      TowerRepository towerRepository,
+      AutoRegisterCity autoRegisterCity,
+      LoginAuthenticationProvider loginAuthenticationProvider) {
     this.towerMapper = towerMapper;
     this.towerRepository = towerRepository;
     this.autoRegisterCity = autoRegisterCity;
+    this.loginAuthenticationProvider = loginAuthenticationProvider;
   }
 
   public TowerDto createTower(TowerDto towerDto) {
+    // TODO: Add the admin ID to the list of members when the tower is created
     Tower tower = towerRepository.save(towerMapper.towerDtoToTower(towerDto));
     return towerMapper.towerToTowerDto(tower);
   }
@@ -43,5 +49,67 @@ public class TowerService {
         towerRepository.findById(towerId).map(towerMapper::towerToTowerDto);
     towerDto.ifPresent(dto -> dto.setCityId(autoRegisterCity.getCityId()));
     return towerDto;
+  }
+
+  public List<TowerDto> getTowersUserIsMemberOf(String userAccountId) {
+    return towerRepository.findAllByMemberAccountIdsContains(userAccountId).stream()
+        .map(towerMapper::towerToTowerDto)
+        .collect(Collectors.toList());
+  }
+
+  public boolean isUserMemberOfTower(String username, String towerId) {
+    String userId = loginAuthenticationProvider.getIdForUsername(username);
+    Optional<Tower> towerOptional = towerRepository.findById(towerId);
+    if (towerOptional.isEmpty()) {
+      // TODO: Make a proper exception
+      throw new RuntimeException("Tower not found");
+    }
+    return towerOptional.get().getMemberAccountIds().contains(userId);
+  }
+
+  public TowerDto joinTower(String username, String towerId) {
+    String userId = loginAuthenticationProvider.getIdForUsername(username);
+    Optional<Tower> towerOptional = towerRepository.findById(towerId);
+    if (towerOptional.isEmpty()) {
+      // TODO: Make a proper exception
+      throw new RuntimeException("Tower not found");
+    }
+    Tower tower = towerOptional.get();
+    if (tower.getMemberAccountIds().contains(userId)) {
+      // TODO: Make a proper exception
+      throw new RuntimeException("User is already a member of that tower");
+    }
+
+    // TODO: Also contact the CIS to add the "member of this City" if applicable
+    tower.getMemberAccountIds().add(userId);
+    return towerMapper.towerToTowerDto(towerRepository.save(tower));
+  }
+
+  public TowerDto leaveTower(String username, String towerId) {
+    String userId = loginAuthenticationProvider.getIdForUsername(username);
+    Optional<Tower> towerOptional = towerRepository.findById(towerId);
+    if (towerOptional.isEmpty()) {
+      // TODO: Make a proper exception
+      throw new RuntimeException("Tower not found");
+    }
+    Tower tower = towerOptional.get();
+    if (!tower.getMemberAccountIds().contains(userId)) {
+      // TODO: Make a proper exception
+      throw new RuntimeException(
+          "User is no longer in that tower. Can't leave a tower you weren't even in.");
+    }
+    // TODO: Also contact the CIS to remove the "member of this City" if applicable
+    tower.getMemberAccountIds().remove(userId);
+    return towerMapper.towerToTowerDto(towerRepository.save(tower));
+  }
+
+  public void deleteTower(String towerId) {
+    if (towerRepository.existsById(towerId)) {
+      // TODO: Also have this contact the CIS to remove "members of this City" if applicable
+      towerRepository.deleteById(towerId);
+    } else {
+      // TODO: Make this a proper exception
+      throw new RuntimeException("Tower not found");
+    }
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/spring/AutoRegisterCity.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/spring/AutoRegisterCity.java
@@ -43,6 +43,9 @@ public class AutoRegisterCity implements ApplicationListener<ContextRefreshedEve
       return;
     }
 
+    // TODO: Even if the IDENTITY file exists, we should still check with the CIS if these
+    // credentials
+    //  are still valid.
     log.info("Checking if this City has been assigned an identity...");
     // Check if saved ID and password exist locally
     if (identityFile.exists()) {

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -4,7 +4,7 @@ tags:
   - name: Account Management
     description: Create and edit an account + view account details by ID
   - name: City Management
-    description: List existing Cities. Register one's self as a City
+    description: List existing Cities.
   - name: Tower User Membership
     description: List towers the user is a member of & join + leave them
   - name: City Interservice Communications
@@ -133,6 +133,33 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
+  '/cities/memberships':
+    get:
+      tags: [ City Management ]
+      summary: List the Cities the user is a "member" of
+      description: |
+        The "member users" of the City are a *fake* concept that exist to assist the frontend in
+        discovering what Towers the user is a member of. Towards that end, the CIS keeps track of
+        what Cities exist and whether the user is a member of _any of the Towers created within
+        that City._ The fact that the CIS has this information allows for the frontend to find out
+        all the Cities that are relevant to the user and then the frontend itself will ask each
+        of those Cities which of its Towers the user is a member of.
+      operationId: listCitiesMemberOf
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                title: CitiesList
+                description: An array of Cities and their details
+                type: array
+                items:
+                  $ref: '#/components/schemas/City'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/cities/{city-id}':
     parameters:
       - $ref: '#/components/parameters/city-id'
@@ -246,6 +273,88 @@ paths:
           description: Invalid credentials
         '404':
           $ref: '#/components/responses/NotFound'
+  '/city-cis-intercom/memberships':
+    get:
+      tags: [ City Interservice Communications ]
+      summary: Get the "member users" of this City
+      description: See the description of `/cities/memberships` for more information on what it means for a City to "have members"
+      operationId: getCityMembers
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    put:
+      tags: [ City Interservice Communications ]
+      summary: Add one or more members to this City
+      description: See the description of `/cities/memberships` for more information on what it means for a City to "have members". The request body should be one or more IDs of users who are now a member of one or more Towers within this City.
+      operationId: addCityMembers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CityMembers'
+      responses:
+        '201':
+          description: Updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CityMembers'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      tags: [ City Interservice Communications ]
+      summary: Set members of this city
+      description: See the description of `/cities/memberships` for more information on what it means for a City to "have members". The request body represents the ID(s) to set as the **ONLY** members of any Towers within this City. This is like the `PUT` method of this endpoint but it replaces the member IDs list instead of adding individual user IDs.
+      operationId: setCityMembers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CityMembers'
+      responses:
+        '201':
+          description: Created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CityMembers'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags: [ City Interservice Communications ]
+      summary: Remove one or more members from this city
+      description: See the description of `/cities/memberships` for more information on what it means for a City to "have members". The request body represents the ID(s) of one or more users who are no longer a member of any Tower within this City.
+      operationId: removeCityMembers
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CityMembers'
+      responses:
+        '200':
+          description: Deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CityMembers'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
 #------------------------------------------------------------------------
 # Components

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -133,6 +133,24 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
+  '/cities/{city-id}':
+    parameters:
+      - $ref: '#/components/parameters/city-id'
+    get:
+      tags: [ City Management ]
+      summary: Get a City by ID
+      operationId: getCity
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/City'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/join/{tower-invite-code}':
     parameters:
       - name: tower-invite-code

--- a/common/src/main/openapi/beacon-city.openapi.yml
+++ b/common/src/main/openapi/beacon-city.openapi.yml
@@ -25,9 +25,14 @@ servers:
     description: Production
 
 paths:
-  '/users/{user-account-id}/memberships':
+  '/memberships':
     parameters:
-      - $ref: '#/components/parameters/user-account-id'
+      - name: user-account-id
+        in: query
+        description: The ID of a user. If empty or not specified, will default to the user sending this request.
+        required: false
+        schema:
+          type: string
     get:
       tags: [ Users ]
       summary: Get Towers the user is a member of

--- a/common/src/main/openapi/beacon-city.openapi.yml
+++ b/common/src/main/openapi/beacon-city.openapi.yml
@@ -125,6 +125,65 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
+    delete:
+      tags: [ Towers ]
+      summary: Delete a tower
+      operationId: deleteTower
+      responses:
+        '200':
+          description: Deleted.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  '/towers/{tower-id}/membership':
+    parameters:
+      - $ref: '#/components/parameters/tower-id'
+    get:
+      tags: [ Towers ]
+      summary: Check if you're the member of a tower
+      operationId: checkIfMemberOfTower
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                type: boolean
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      tags: [ Towers ]
+      summary: Join a tower
+      operationId: joinTower
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tower'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags: [ Towers ]
+      summary: Leave a tower
+      operationId: leaveTower
+      responses:
+        '200':
+          description: Ok.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tower'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
   '/towers/{tower-id}/create-invite':
     parameters:
       - $ref: '#/components/parameters/tower-id'

--- a/common/src/main/openapi/parameters/_index.yaml
+++ b/common/src/main/openapi/parameters/_index.yaml
@@ -6,3 +6,5 @@ channel-id:
   $ref: "./path/channel-id.yml"
 message-id:
   $ref: "./path/message-id.yml"
+city-id:
+  $ref: "./path/city-id.yml"

--- a/common/src/main/openapi/parameters/path/city-id.yml
+++ b/common/src/main/openapi/parameters/path/city-id.yml
@@ -1,0 +1,6 @@
+name: city-id
+in: path
+description: The ID of a City
+required: true
+schema:
+  type: string

--- a/common/src/main/openapi/schemas/CityMembers.yml
+++ b/common/src/main/openapi/schemas/CityMembers.yml
@@ -1,0 +1,5 @@
+title: CityMembers
+description: A list of IDs representing the users who exist within one or more Towers contained within this City
+type: array
+items:
+  type: string

--- a/common/src/main/openapi/schemas/Tower.yml
+++ b/common/src/main/openapi/schemas/Tower.yml
@@ -5,6 +5,10 @@ properties:
     description: The unique ID of this Tower
     type: string
     example: 507f1f77bcf86cd799439011
+  city_id:
+    description: The ID of the City that this Tower belongs to
+    type: string
+    example: 507f1f77bcf86cd799439011
   name:
     description: The name of this tower
     type: string

--- a/common/src/main/openapi/schemas/Tower.yml
+++ b/common/src/main/openapi/schemas/Tower.yml
@@ -22,3 +22,8 @@ properties:
     type: array
     items:
       type: string
+  member_account_ids:
+    description: The account IDs of the members of this Tower.
+    type: array
+    items:
+      type: string

--- a/common/src/main/openapi/schemas/_index.yaml
+++ b/common/src/main/openapi/schemas/_index.yaml
@@ -18,3 +18,5 @@ Channel:
   $ref: "./Channel.yml"
 Message:
   $ref: "./Message.yml"
+CityMembers:
+  $ref: "./CityMembers.yml"


### PR DESCRIPTION
Before this PR, we merely had Towers that simply existed. There was no concept of a user being a member of a Tower. This PR changes that and adds a lot of other stuff that will be necessary for that concept to work across multiple Cities. This does not yet implement invites. That'll be another big PR of its own.

To summarize the problem, say we have a user named Bob. Let's say Bob is a member of the DOOM Tower which is hosted on our centralized City, the one anyone can use if they don't feel like hosting their own. Bob is also a member of his friend Joe's Tower called My Friends Are Fools. Joe made this Tower on a City that he hosts himself.

That's all fine. However, how does the web client know what Towers Bob is a member of? The centralized City and Joe's City could just have a `memberIds` list in the Tower object that would keep track of who is a member of that Tower. That's actually one of the things that's done in this PR. However, there's still one problem. Sure, the client could come hardcoded with the centralized City's URL but how would it ever know that Bob is a member of a Tower on a City hosted by his friend? It wouldn't. That's where the next big change comes in, the concept of "City members".

The CIS has to at least _keep track_ of all the existing Cities in some way to give them an ID and credentials for them to send requests to the CIS. One more piece of information could be stored, "members of the City". I use quotes here because a City can't have members. The concept of "members of a City" is merely a shorthand to denote an array in the City object that has the IDs of all users who are a member of one or more Towers within that City. This solves the problem of the client not being aware that Bob is a member of a Tower on a self-hosted City.

With this solution implemented, here are the steps the client would perform on startup to be able to know what Towers Bob is a member of regardless of whether it's on a City hosted by us
1. Ask the CIS what Cities Bob is a member of (again, this is just a shorter way of asking what Cities host any Towers that Bob is a member of) by sending a `GET` to the [/cities/memberships](https://beacon-cis-pr-27.herokuapp.com/swagger-ui/index.html#/City%20Management/listCitiesMemberOf) CIS endpoint
2. For each City on the returned list of objects (which are literally just an ID paired with a URL)
   1. Send a `GET` request to that City's [/memberships](https://beacon-city-pr-27.herokuapp.com/swagger-ui/index.html#/Users/getUserTowerMemberships) endpoint

Boom. It's that simple. There's one small caveat to this. It is the responsibility of all Cities to report to the CIS when somebody joins one of its Towers who previously wasn't a member of any of them. That way, the CIS can add that user's ID to the list of "City members" in the CIS database. This also goes for when a user, who is only a member of one Tower on a given City, leaves that tower. Since the user isn't a member of any of the Towers it hosts anymore, that City needs to tell the CIS to remove that user ID from the list of "City members".

This PR description is already getting _quite_ lengthy. For the changes, I recommend you look at the API changes on the sites Heroku has deployed for this PR. Also feel free to take a look at the messages for the 9 commits this introduces.