### PR TITLE
Fixed Tower creation bug

### DIFF
--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -41,6 +41,8 @@ public class TowerService {
 
   public TowerDto createTower(String username, TowerDto towerDto) {
     String userId = loginAuthenticationProvider.getIdForUsername(username);
+    // Set the Tower creator as the admin of this Tower
+    towerDto.setAdminAccountId(userId);
     // Initialize member IDs
     towerDto.setMemberAccountIds(new ArrayList<>());
     // Initialize moderator ID list


### PR DESCRIPTION
When creating a Tower, the person who created it should be the admin of that Tower. I forgot to add this line (I was changing a lot of things at once). This also prevents someone from supplying their own value for the `adminId` field and creating a Tower that they're the only member of but not the administrator of.