### PR TITLE
Fix the CIS forgetting the members of a City

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/CityService.java
@@ -66,9 +66,16 @@ public class CityService {
     // A UUID should work decently well for a password I suppose.
     String passwordRaw = UUID.randomUUID().toString();
     city.setPassword(passwordEncoder.encode(passwordRaw));
-    // The City needs to have the members list initialized. Otherwise, it'll be null and cause
-    // problems for us when we want to retrieve the list and modify it.
-    city.setMemberUsers(new ArrayList<>());
+    /*
+    This will be null in the case of a new City. However, if an old City lost its identity and
+    tried to re-establish itself (like what happens with Heroku apps that have temporary storage
+    which is wiped when they are suspended), we don't want to wipe out the existing members list.
+     */
+    if (city.getMemberUsers() == null) {
+      // The City needs to have the members list initialized. Otherwise, it'll be null and cause
+      // problems for us when we want to retrieve the list and modify it.
+      city.setMemberUsers(new ArrayList<>());
+    }
     NewCityDto newCity = cityMapper.cityToNewCityDto(cityRepository.save(city));
     // We don't want to send back the encoded password.
     // Otherwise, the City won't ever be able to authenticate properly


### PR DESCRIPTION
This fixes a bug introduced in #27. Something I was aware of with Heroku apps is that [after 30 minutes, they go to sleep](https://blog.heroku.com/app_sleeping_on_heroku) (more details [here](https://devcenter.heroku.com/articles/free-dyno-hours#dyno-sleeping)). Something I wasn't aware of is that they have no persistent file storage. This means that whenever the City service writes its IDENTITY file, that file is lost when the dyno goes to sleep. When the City wakes up again, it sees that it has no IDENTITY file and contacts the [`/city-cis-intercom/register-city`](https://beacon-cis-main-staging.herokuapp.com/swagger-ui/index.html#/City%20Interservice%20Communications/registerCity) CIS endpoint. The CIS checks if there is a City that already exists with the base URL that the "new" City has provided. If there is, it simply sets a new password for that City but lets the ID remain the same. I didn't know this was the case until I had the City members property get initialized every time a new City is registered. What I didn't realize is that this was wiping out any _existing_ array. Now there's a check in case this City already exists and has an array of members.