### PR TITLE
Replace some null returns with an exception

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityInterserviceCommunicationsController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/CityInterserviceCommunicationsController.java
@@ -9,6 +9,7 @@ import io.github.incplusplus.beacon.centralidentityserver.security.IAuthenticati
 import io.github.incplusplus.beacon.centralidentityserver.service.CityService;
 import io.github.incplusplus.beacon.centralidentityserver.service.UserService;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -54,7 +55,7 @@ public class CityInterserviceCommunicationsController implements CityInterservic
   public ResponseEntity<String> generateTowerInvite(
       CreateTowerInviteRequestDto createTowerInviteRequestDto) {
     // TODO Implement this
-    return null;
+    throw new NotImplementedException("Logic to generate Tower invites not implemented yet.");
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/MessageController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/MessageController.java
@@ -5,6 +5,7 @@ import io.github.incplusplus.beacon.city.generated.dto.MessageDto;
 import io.github.incplusplus.beacon.city.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.city.service.MessageService;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -38,14 +39,14 @@ public class MessageController implements MessagesApi {
   public ResponseEntity<MessageDto> deleteMessage(
       String towerId, String channelId, String messageId) {
     // TODO: Implement
-    return null;
+    throw new NotImplementedException("Logic to delete messages not implemented yet.");
   }
 
   @Override
   public ResponseEntity<MessageDto> editMessage(
       String towerId, String channelId, String messageId, MessageDto messageDto) {
     // TODO: Implement
-    return null;
+    throw new NotImplementedException("Logic to edit messages not implemented yet.");
   }
 
   @Override

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/TowerController.java
@@ -5,6 +5,7 @@ import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
 import io.github.incplusplus.beacon.city.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.city.service.TowerService;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -65,6 +66,7 @@ public class TowerController implements TowersApi {
   @Override
   public ResponseEntity<List<String>> listTowersIds() {
     // TODO: Implement
-    return null;
+    throw new NotImplementedException(
+        "The endpoint to list tower IDs isn't implemented yet. I might not even bother with it since we don't seem to have a use for it.");
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/controller/UserController.java
@@ -5,6 +5,7 @@ import io.github.incplusplus.beacon.city.generated.dto.TowerDto;
 import io.github.incplusplus.beacon.city.security.IAuthenticationFacade;
 import io.github.incplusplus.beacon.city.service.TowerService;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -23,7 +24,7 @@ public class UserController implements UsersApi {
   @Override
   public ResponseEntity<String> createInvite(String towerId) {
     // TODO Implement
-    return null;
+    throw new NotImplementedException("Logic to generate Tower invites not implemented yet.");
   }
 
   @Override


### PR DESCRIPTION
There are some endpoints that exist but aren't implemented yet. I marked them with a TODO and had them return null. However, as I just found out, this leads to confusing exceptions when being used by the frontend client such as "SyntaxError: Unexpected end of JSON input". Now they throw an exception instead of returning null. I'll implement these eventually.