### PR TITLE
Prevent OpenAPI YML from files being cached

### DIFF
--- a/common/src/main/java/io/github/incplusplus/beacon/common/config/MvcConfigurationBase.java
+++ b/common/src/main/java/io/github/incplusplus/beacon/common/config/MvcConfigurationBase.java
@@ -45,6 +45,7 @@ public class MvcConfigurationBase implements WebMvcConfigurer {
     registry
         .addResourceHandler("/v3/api-docs.yml")
         .addResourceLocations("classpath:/static")
+        .setCachePeriod(0)
         .resourceChain(true)
         .addResolver(
             new PathResourceResolver() {


### PR DESCRIPTION
This fixes #11. Basically, whenever viewing the Swagger documentation for the City or CIS, my browser was caching the response of /v3/api-docs.yml which is the request sent by the browser to retrieve the OpenAPI YML file. By default, Spring's ResourceHandlers will permit the browser to cache responses and rely on the Last-Modified header to inform the browser if its version was out of date. I found that this caused the browser to often never get the new version of the spec even if we recently pushed an update to Heroku. According to [the JavaDoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/config/annotation/ResourceHandlerRegistration.html#setCachePeriod-java.lang.Integer-), all we have to do is add setCachePeriod(0) to our ResourceHandler to send headers that forbid the browser from caching the response. I checked for myself, and it now seems to no longer cache the YML file as one of the response headers is "Cache-Control: no-store" (see [here](https://devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#http-cache-headers) for info on what the Cache-Control header values mean. [This](https://developers.google.com/web/fundamentals/performance/get-started/httpcaching-6) article is also pretty informative). I also noticed that Chrome would no longer retrieve the file from the disk cache and would always retrieve it from the server. This is the desired behavior.