### PR TITLE
Point the production City instance at the QA CIS instance

### DIFF
--- a/city/src/main/resources/application-heroku-prod.yml
+++ b/city/src/main/resources/application-heroku-prod.yml
@@ -3,5 +3,5 @@ spring:
     mongodb:
       uri: mongodb+srv://springMongoUser:${MONGODB_PASSWORD}@prodcluster0.bdjwu.mongodb.net/beacon-city-prod?retryWrites=true&w=majority
 city:
-  cis-url: https://beacon-cis.herokuapp.com
+  cis-url: https://beacon-cis-main-staging.herokuapp.com
   hostname: beacon-city.herokuapp.com


### PR DESCRIPTION
This was done temporarily just so that we had two City instances running on separate machines with separate databases for demonstration purposes. By default, the production City is configured to point at a production CIS instance. However, that'd mess up identity stuff so we're gonna point it at our existing CIS that we'll be using for the demo.

This should be reverted after we're done with the demo. Created #39 to keep track of this.