### PR TITLE
Revert "Bump pl.allegro.tech.build.axion-release from 1.13.6 to 1.13.9"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     // https://stackoverflow.com/a/26240341/1687436
     id "com.diffplug.spotless" version "6.6.1" apply false
     // https://axion-release-plugin.readthedocs.io/en/latest/configuration/basic_usage/#multi-module-project
-    id 'pl.allegro.tech.build.axion-release' version '1.13.9'
+    id 'pl.allegro.tech.build.axion-release' version '1.13.6'
 }
 
 scmVersion {


### PR DESCRIPTION
This reverts commit 7c9d44395d545a56f9c71c89486b764827758b13. For some reason, Gradle keeps trying to push the wrong tag. That wasn't a problem until the recent axion-release plugin update.