### PR TITLE
Allow the CIS /account/{user-account-id} endpoint to accept a blank account ID

### DIFF
--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/config/SecurityConfig.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -56,7 +57,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     // @formatter:off
     http.csrf().disable()
         .authorizeRequests()
-          .antMatchers("/account/create-new-account").permitAll()
+          .antMatchers(HttpMethod.POST,"/account").permitAll()
           .antMatchers("/city-cis-intercom/register-city").permitAll()
           .antMatchers("/invalidSession*").anonymous()
           .antMatchers("/city-cis-intercom/**").hasRole("CITY")

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
@@ -53,15 +53,24 @@ public class UserService {
   }
 
   /**
-   * @param userAccountId the ID of the account to find
+   * @param userAccountId the ID of the account to find. If blank, this will request info about the
+   *     account that sent this request (retrieved from the second parameter)
    * @param usernameOfAccountRequestingInfo the ID of the account requesting this information
    * @return the account information requested. For privacy reasons, the email address will be
    *     redacted if the requested account is not the same as the account sending the request.
    */
   public Optional<UserAccountDto> publicGetAccountById(
       String userAccountId, String usernameOfAccountRequestingInfo) {
-    return userRepository
-        .findById(userAccountId)
+    Optional<User> accountInQuestion;
+    // If no user account ID was provided
+    if (userAccountId == null || userAccountId.isBlank()) {
+      // Then the request is actually asking for info about the user who sent the request
+      accountInQuestion = userRepository.findByUsername(usernameOfAccountRequestingInfo);
+    } else {
+      // Otherwise, find the account denoted by the ID that was provided in the request
+      accountInQuestion = userRepository.findById(userAccountId);
+    }
+    return accountInQuestion
         // Map user Document to a DTO in preparation for returning to the controller
         .map(userMapper::userToUserDto)
         // Redact the email address if the user who is requesting this info isn't the user who is

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -72,7 +72,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
-  '/account/{user-account-id}':
+  '/account':
     parameters:
       - name: user-account-id
         in: query

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -25,7 +25,7 @@ servers:
     description: Production
 
 paths:
-  '/account/create-new-account':
+  '/account':
     post:
       tags: [ Account Management ]
       summary: Create a new user account
@@ -45,6 +45,30 @@ paths:
                 $ref: '#/components/schemas/UserAccount'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    get:
+      tags: [ Account Management ]
+      summary: Get information about the user with the specified ID
+      parameters:
+        - name: user-account-id
+          in: query
+          description: The ID of a user. If empty or not specified, will default to the user sending this request.
+          required: false
+          schema:
+            type: string
+      operationId: getAccount
+      responses:
+        '200':
+          description: Ok. Operation successful.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAccount'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
   '/account/update-profile-picture':
@@ -70,31 +94,6 @@ paths:
                 $ref: '#/components/schemas/UserAccount'
         '400':
           $ref: '#/components/responses/BadRequest'
-        '500':
-          $ref: '#/components/responses/ServerError'
-  '/account':
-    parameters:
-      - name: user-account-id
-        in: query
-        description: The ID of a user. If empty or not specified, will default to the user sending this request.
-        required: false
-        schema:
-          type: string
-    get:
-      tags: [ Account Management ]
-      summary: Get information about the user with the specified ID
-      operationId: getAccount
-      responses:
-        '200':
-          description: Ok. Operation successful.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserAccount'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
   '/account/{user-account-id}/profile-picture':

--- a/common/src/main/openapi/beacon-central-identity-server.openapi.yml
+++ b/common/src/main/openapi/beacon-central-identity-server.openapi.yml
@@ -74,7 +74,12 @@ paths:
           $ref: '#/components/responses/ServerError'
   '/account/{user-account-id}':
     parameters:
-      - $ref: '#/components/parameters/user-account-id'
+      - name: user-account-id
+        in: query
+        description: The ID of a user. If empty or not specified, will default to the user sending this request.
+        required: false
+        schema:
+          type: string
     get:
       tags: [ Account Management ]
       summary: Get information about the user with the specified ID


### PR DESCRIPTION
This will return the information for the user who sent the request.

THIS CHANGES WHAT THE ENDPOINT URI IS. PLEASE SEE THE NEW DOCS AT https://beacon-cis-pr-63.herokuapp.com/swagger-ui/index.html#/Account%20Management/createNewAccount