### PR TITLE
Make profile pictures & Tower icon + banner URLs always unique

### DIFF
--- a/central-identity-server/build.gradle
+++ b/central-identity-server/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation 'org.zalando:problem-spring-web-starter:0.28.0-RC.0'
     // Because Guava has some great utility methods
     implementation 'com.google.guava:guava:31.1-jre'
+    // For TSID generation
+    implementation 'com.github.f4b6a3:tsid-creator:4.2.1'
     // For storing profile pictures
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.232'
 

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/AccountManagementController.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/controller/AccountManagementController.java
@@ -54,7 +54,7 @@ public class AccountManagementController implements AccountManagementApi {
       throw new UnsupportedFileTypeException(picture.getContentType(), "image/png");
     }
     return ResponseEntity.of(
-        userService.store(
+        userService.updateProfilePicture(
             picture,
             userService
                 .getAccountByUsername(authenticationFacade.getAuthentication().getName())

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
@@ -174,7 +174,7 @@ public class UserService {
     if (accountOptional.isPresent()) {
       User user = accountOptional.get();
       // Update the profile picture URL on their account
-      user.setProfilePictureUrl(getProfilePictureUrlForId(userId, tsid));
+      user.setProfilePictureUrl(getProfilePictureEdgeUrlForId(userId, tsid));
       // Save the changes, and put it back in the Optional which will then be converted to a DTO
       accountOptional = Optional.of(userRepository.save(user));
     }

--- a/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
+++ b/central-identity-server/src/main/java/io/github/incplusplus/beacon/centralidentityserver/service/UserService.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.github.f4b6a3.tsid.TsidCreator;
 import io.github.incplusplus.beacon.centralidentityserver.exception.UserAlreadyExistsException;
 import io.github.incplusplus.beacon.centralidentityserver.generated.dto.CreateAccountRequestDto;
 import io.github.incplusplus.beacon.centralidentityserver.generated.dto.UserAccountDto;
@@ -17,6 +18,8 @@ import io.github.incplusplus.beacon.centralidentityserver.persistence.model.User
 import io.github.incplusplus.beacon.common.exception.StorageException;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -27,6 +30,11 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional
 public class UserService {
+
+  /** Group 1 is the endpoint. Group 2 is the user ID. Group 3 is the TSID. */
+  private final Pattern profilePictureUrlPattern =
+      Pattern.compile(
+          "(https://beaconcdn.nyc3.digitaloceanspaces.com/pfps/|https://beaconcdn.nyc3.cdn.digitaloceanspaces.com/pfps/)([a-f\\d]+)/(\\d+)\\.png");
 
   private final AmazonS3 s3Client;
 
@@ -122,8 +130,31 @@ public class UserService {
     return userRepository.findByUsername(username);
   }
 
-  public Optional<UserAccountDto> store(MultipartFile picture, String userId) {
-    String fileKey = "pfps/" + userId + ".png";
+  public Optional<UserAccountDto> updateProfilePicture(MultipartFile picture, String userId) {
+    deleteCurrentProfilePicture(userId);
+    return setProfilePicture(picture, userId);
+  }
+
+  private void deleteCurrentProfilePicture(String userId) {
+    Optional<User> userOptional = getAccountById(userId);
+    if (userOptional.isPresent()) {
+      User user = userOptional.get();
+      try {
+        s3Client.deleteObject(
+            "beaconcdn", getFileKeyForProfilePictureUrl(user.getProfilePictureUrl()));
+      } catch (IllegalStateException ignored) {
+        // The pfp may not have been set before or is some wack URL. Just ignore it.
+        // It's okay if we can't figure out something to delete.
+      }
+      user.setProfilePictureUrl("");
+      userRepository.save(user);
+    }
+  }
+
+  private Optional<UserAccountDto> setProfilePicture(MultipartFile picture, String userId) {
+    // This isn't exactly the smartest way to use a TSID, but it's good enough for now.
+    long tsid = TsidCreator.getTsid256().toLong();
+    String fileKey = "pfps/" + userId + "/" + tsid + ".png";
     ObjectMetadata metadata = new ObjectMetadata();
     try {
       metadata.setContentLength(picture.getInputStream().available());
@@ -143,18 +174,27 @@ public class UserService {
     if (accountOptional.isPresent()) {
       User user = accountOptional.get();
       // Update the profile picture URL on their account
-      user.setProfilePictureUrl(getProfilePictureUrlForId(userId));
+      user.setProfilePictureUrl(getProfilePictureUrlForId(userId, tsid));
       // Save the changes, and put it back in the Optional which will then be converted to a DTO
       accountOptional = Optional.of(userRepository.save(user));
     }
     return accountOptional.map(userMapper::userToUserDto);
   }
 
-  private String getProfilePictureUrlForId(String userId) {
-    return "https://beaconcdn.nyc3.digitaloceanspaces.com/pfps/" + userId + ".png";
+  private String getFileKeyForProfilePictureUrl(String url) {
+    Matcher matcher = profilePictureUrlPattern.matcher(url);
+    if (!matcher.find()) {
+      throw new IllegalStateException(
+          "The current pfp URL '" + url + "' is unrecognized. Someone pranked you good.");
+    }
+    return "pfps/" + matcher.group(2) + "/" + matcher.group(3) + ".png";
   }
 
-  private String getProfilePictureEdgeUrlForId(String userId) {
-    return "https://beaconcdn.nyc3.cdn.digitaloceanspaces.com/pfps/" + userId + ".png";
+  private String getProfilePictureUrlForId(String userId, long tsid) {
+    return "https://beaconcdn.nyc3.digitaloceanspaces.com/pfps/" + userId + "/" + tsid + ".png";
+  }
+
+  private String getProfilePictureEdgeUrlForId(String userId, long tsid) {
+    return "https://beaconcdn.nyc3.cdn.digitaloceanspaces.com/pfps/" + userId + "/" + tsid + ".png";
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/StorageService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/StorageService.java
@@ -23,18 +23,21 @@ public interface StorageService {
    *
    * @param icon a PNG file
    * @param towerId the ID of the tower
+   * @param existingUrl the current URL of the tower icon
    * @return a URL that points to the newly-uploaded file
    * @throws IOException if the file couldn't be uploaded
    */
-  String saveTowerIcon(MultipartFile icon, String towerId) throws IOException;
+  String saveTowerIcon(MultipartFile icon, String towerId, String existingUrl) throws IOException;
 
   /**
    * Upload an image to be used as the banner for a tower.
    *
    * @param banner a PNG file
    * @param towerId the ID of the tower
+   * @param existingUrl the current URL of the tower banner
    * @return a URL that points to the newly-uploaded file
    * @throws IOException if the file couldn't be uploaded
    */
-  String saveTowerBanner(MultipartFile banner, String towerId) throws IOException;
+  String saveTowerBanner(MultipartFile banner, String towerId, String existingUrl)
+      throws IOException;
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/TowerService.java
@@ -257,7 +257,7 @@ public class TowerService {
         if (icon.getContentType() == null || !icon.getContentType().equals("image/png")) {
           throw new UnsupportedFileTypeException(icon.getContentType(), "image/png");
         }
-        tower.setIconUrl(storageService.saveTowerIcon(icon, tower.getId()));
+        tower.setIconUrl(storageService.saveTowerIcon(icon, tower.getId(), tower.getIconUrl()));
       }
     }
     return tower;
@@ -271,7 +271,8 @@ public class TowerService {
         if (banner.getContentType() == null || !banner.getContentType().equals("image/png")) {
           throw new UnsupportedFileTypeException(banner.getContentType(), "image/png");
         }
-        tower.setBannerUrl(storageService.saveTowerBanner(banner, tower.getId()));
+        tower.setBannerUrl(
+            storageService.saveTowerBanner(banner, tower.getId(), tower.getBannerUrl()));
       }
     }
     return tower;

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
@@ -87,16 +87,16 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
   @Override
   public String saveTowerIcon(MultipartFile icon, String towerId, String existingUrl)
       throws IOException {
-    return saveTowerOrBanner(icon, towerId, true, existingUrl);
+    return saveTowerIconOrBanner(icon, towerId, true, existingUrl);
   }
 
   @Override
   public String saveTowerBanner(MultipartFile banner, String towerId, String existingUrl)
       throws IOException {
-    return saveTowerOrBanner(banner, towerId, false, existingUrl);
+    return saveTowerIconOrBanner(banner, towerId, false, existingUrl);
   }
 
-  private String saveTowerOrBanner(
+  private String saveTowerIconOrBanner(
       MultipartFile file, String towerId, boolean isIcon, String existingUrl) throws IOException {
     // This isn't exactly the smartest way to use a TSID, but it's good enough for now.
     long tsid = TsidCreator.getTsid256().toLong();
@@ -117,7 +117,7 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
         new PutObjectRequest(props.getBucket(), fileKey, file.getInputStream(), metadata)
             .withCannedAcl(CannedAccessControlList.PublicRead));
 
-    return getFileOriginUrl(fileKey);
+    return getIconOrBannerEdgeUrl(fileKey, tsid, isIcon);
   }
 
   private String getIconOrBannerOriginUrl(String towerId, long tsid, boolean isIcon) {

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
@@ -12,6 +12,8 @@ import com.github.f4b6a3.tsid.TsidCreator;
 import io.github.incplusplus.beacon.city.properties.DigitalOceanStorageProperties;
 import io.github.incplusplus.beacon.city.service.StorageService;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @ConditionalOnProperty(prefix = "do.spaces", value = "key")
 public class DigitalOceanSpacesStorageImpl implements StorageService {
+  private final Pattern bannerOrIconUrlPattern;
   private final DigitalOceanStorageProperties props;
 
   private final AmazonS3 s3Client;
@@ -38,6 +41,28 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
                 new EndpointConfiguration(props.getEndpoint(), props.getRegion()))
             .withCredentials(new AWSStaticCredentialsProvider(creds))
             .build();
+    // This is awful lol
+    bannerOrIconUrlPattern =
+        Pattern.compile(
+            "("
+                // Basically this gets the origin bucket URL
+                + "https://"
+                + props.getBucket()
+                + "."
+                + props.getEndpoint()
+                + "/"
+                // OR
+                + "|"
+                // the cdn URL
+                + props.getBucket()
+                + "."
+                + props.getRegion()
+                + ".cdn."
+                + getDomainFromEndpoint()
+                + "/"
+                + ")"
+                // followed by the elements of the file path
+                + "([a-f\\d]+)/(icon|banner)-(\\d+)\\.png");
   }
 
   @Override
@@ -60,28 +85,71 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
   }
 
   @Override
-  public String saveTowerIcon(MultipartFile icon, String towerId) throws IOException {
-    return saveTowerOrBanner(icon, towerId, true);
+  public String saveTowerIcon(MultipartFile icon, String towerId, String existingUrl)
+      throws IOException {
+    return saveTowerOrBanner(icon, towerId, true, existingUrl);
   }
 
   @Override
-  public String saveTowerBanner(MultipartFile banner, String towerId) throws IOException {
-    return saveTowerOrBanner(banner, towerId, false);
+  public String saveTowerBanner(MultipartFile banner, String towerId, String existingUrl)
+      throws IOException {
+    return saveTowerOrBanner(banner, towerId, false, existingUrl);
   }
 
-  private String saveTowerOrBanner(MultipartFile file, String towerId, boolean isIcon)
-      throws IOException {
+  private String saveTowerOrBanner(
+      MultipartFile file, String towerId, boolean isIcon, String existingUrl) throws IOException {
+    // This isn't exactly the smartest way to use a TSID, but it's good enough for now.
+    long tsid = TsidCreator.getTsid256().toLong();
+    // Delete the existing file if it exists
+    try {
+      s3Client.deleteObject(props.getBucket(), getFileKeyForIconOrBannerUrl(existingUrl));
+    } catch (IllegalStateException ignored) {
+      // It may be the case that the URL hasn't been set yet. We can ignore this.
+    }
+
     ObjectMetadata metadata = new ObjectMetadata();
     metadata.setContentLength(file.getInputStream().available());
     if (file.getContentType() != null && !"".equals(file.getContentType())) {
       metadata.setContentType(file.getContentType());
     }
-    String fileKey = towerId + "/" + (isIcon ? "icon.png" : "banner.png");
+    String fileKey = towerId + "/" + (isIcon ? "icon" : "banner") + "-" + tsid + ".png";
     s3Client.putObject(
         new PutObjectRequest(props.getBucket(), fileKey, file.getInputStream(), metadata)
             .withCannedAcl(CannedAccessControlList.PublicRead));
 
     return getFileOriginUrl(fileKey);
+  }
+
+  private String getIconOrBannerOriginUrl(String towerId, long tsid, boolean isIcon) {
+    // https://beaconcdn.nyc3.digitaloceanspaces.com/623de7d41b2b8c392b5e23d0/icon-12312321.png
+    return "https://"
+        + props.getBucket()
+        + "."
+        + props.getEndpoint()
+        + "/"
+        + towerId
+        + "/"
+        + (isIcon ? "icon" : "banner")
+        + "-"
+        + tsid
+        + ".png";
+  }
+
+  private String getIconOrBannerEdgeUrl(String towerId, long tsid, boolean isIcon) {
+    // https://beaconcdn.nyc3.cdn.digitaloceanspaces.com/623de7d41b2b8c392b5e23d0/banner-123241.png
+    return "https://"
+        + props.getBucket()
+        + "."
+        + props.getRegion()
+        + ".cdn."
+        + getDomainFromEndpoint()
+        + "/"
+        + towerId
+        + "/"
+        + (isIcon ? "icon" : "banner")
+        + "-"
+        + tsid
+        + ".png";
   }
 
   private String getFileOriginUrl(String fileKey) {
@@ -95,7 +163,22 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
         + props.getBucket()
         + "."
         + props.getRegion()
-        + ".cdn.digitaloceanspaces.com/"
+        + ".cdn."
+        + getDomainFromEndpoint()
+        + "/"
         + fileKey;
+  }
+
+  private String getDomainFromEndpoint() {
+    return props.getEndpoint().substring(props.getEndpoint().indexOf("."));
+  }
+
+  private String getFileKeyForIconOrBannerUrl(String url) {
+    Matcher matcher = bannerOrIconUrlPattern.matcher(url);
+    if (!matcher.find()) {
+      throw new IllegalStateException(
+          "Icon or banner for url '" + url + "' doesn't seem quite right. Unable to delete it.");
+    }
+    return matcher.group(2) + "/" + matcher.group(3) + "-" + matcher.group(4) + ".png";
   }
 }

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/LocalStorageImpl.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/LocalStorageImpl.java
@@ -5,21 +5,27 @@ import io.github.incplusplus.beacon.city.properties.LocalStorageProperties;
 import io.github.incplusplus.beacon.city.service.StorageService;
 import io.github.incplusplus.beacon.city.spring.AutoRegisterCity;
 import io.github.incplusplus.beacon.common.exception.StorageException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 /** The default storage provider for user-uploaded content. */
+@Slf4j
 @Service
 @ConditionalOnMissingBean(value = StorageService.class, ignored = LocalStorageImpl.class)
 public class LocalStorageImpl implements StorageService {
+  private final Pattern bannerOrIconUrlPattern;
 
   private final Path rootLocation;
 
@@ -29,6 +35,11 @@ public class LocalStorageImpl implements StorageService {
   public LocalStorageImpl(LocalStorageProperties properties, AutoRegisterCity autoRegisterCity) {
     this.rootLocation = Paths.get(properties.getLocation());
     this.autoRegisterCity = autoRegisterCity;
+    bannerOrIconUrlPattern =
+        Pattern.compile(
+            "https://"
+                + autoRegisterCity.getHostName()
+                + "/attachments/([a-f\\d]+)/(icon|banner)-(\\d+)\\.png");
   }
 
   @Override
@@ -71,17 +82,24 @@ public class LocalStorageImpl implements StorageService {
   }
 
   @Override
-  public String saveTowerIcon(MultipartFile icon, String towerId) {
-    return saveTowerIconOrBanner(icon, towerId, true);
+  public String saveTowerIcon(MultipartFile icon, String towerId, String existingUrl) {
+    return saveTowerIconOrBanner(icon, towerId, true, existingUrl);
   }
 
   @Override
-  public String saveTowerBanner(MultipartFile banner, String towerId) {
-    return saveTowerIconOrBanner(banner, towerId, false);
+  public String saveTowerBanner(MultipartFile banner, String towerId, String existingUrl) {
+    return saveTowerIconOrBanner(banner, towerId, false, existingUrl);
   }
 
-  private String saveTowerIconOrBanner(MultipartFile file, String towerId, boolean isIcon) {
-    String fileName = isIcon ? "icon.png" : "banner.png";
+  private String saveTowerIconOrBanner(
+      MultipartFile file, String towerId, boolean isIcon, String existingUrl) {
+    // Clean up the older icon or banner file
+    deleteOldBannerOrIcon(existingUrl);
+
+    // This isn't exactly the smartest way to use a TSID, but it's good enough for now.
+    long tsid = TsidCreator.getTsid256().toLong();
+    String fileName = (isIcon ? "icon" : "banner") + "-" + tsid + ".png";
+
     Path attachmentPath = Paths.get(towerId, fileName);
     try {
       if (file.isEmpty()) {
@@ -113,5 +131,22 @@ public class LocalStorageImpl implements StorageService {
         // I know this sucks. Shut up.
         + "/attachments/"
         + attachmentPath.toString().replace("\\", "/");
+  }
+
+  private void deleteOldBannerOrIcon(String url) {
+    Matcher matcher = bannerOrIconUrlPattern.matcher(url);
+    if (!matcher.find()) {
+      throw new IllegalStateException("Couldn't determine previous URL for banner or icon.");
+    }
+    Path target =
+        this.rootLocation
+            .resolve(
+                Paths.get(matcher.group(1), matcher.group(2) + "-" + matcher.group(3) + ".png"))
+            .normalize()
+            .toAbsolutePath();
+    File file = target.toFile();
+    if (!file.delete()) {
+      log.warn("Unable to delete file at " + file.getAbsolutePath());
+    }
   }
 }


### PR DESCRIPTION
Fixes #92 and rolls back the changes made in #93. This is necessary for IncPlusPlus/beacon-frontend#49 to work as expected.

When updating a profile picture icon as well as the Tower icon/banner images, the old file is now deleted from the S3 storage service we use or the local storage if applicable. Additionally, the new file gets a slightly different name using a time-based unique ID.