### PR TITLE
Fix DO file URLs being wrong

### DIFF
--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
@@ -172,7 +172,7 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
   }
 
   private String getDomainFromEndpoint() {
-    return props.getEndpoint().substring(props.getEndpoint().indexOf("."));
+    return props.getEndpoint().substring(props.getEndpoint().indexOf(".") + 1);
   }
 
   private String getFileKeyForIconOrBannerUrl(String url) {

--- a/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
+++ b/city/src/main/java/io/github/incplusplus/beacon/city/service/storage/DigitalOceanSpacesStorageImpl.java
@@ -119,7 +119,7 @@ public class DigitalOceanSpacesStorageImpl implements StorageService {
         new PutObjectRequest(props.getBucket(), fileKey, file.getInputStream(), metadata)
             .withCannedAcl(CannedAccessControlList.PublicRead));
 
-    return getIconOrBannerEdgeUrl(fileKey, tsid, isIcon);
+    return getIconOrBannerEdgeUrl(towerId, tsid, isIcon);
   }
 
   private String getIconOrBannerOriginUrl(String towerId, long tsid, boolean isIcon) {


### PR DESCRIPTION
The DigitalOcean storage URLs were being incorrectly generated. `https://beaconcdn.nyc3.cdn..digitaloceanspaces.com/507f1f77bcf86cd799439011/icon-334035869618203717.png/icon-334035869618203717.png` is an example of this. There are two dots and the file appears twice in the path. This PR resolves that.